### PR TITLE
Preserve homepage layout with empty announcements

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -29,6 +29,7 @@ export default defineConfig([
             'unicorn/filename-case': 'off',
             'unicorn/prevent-abbreviations': 'off',
             'unicorn/no-null': 'off',
+            'unicorn/no-lonely-if': 'off',
             'no-unused-vars': 'off',
             '@typescript-eslint/no-unused-vars': ['error', {
                 vars: 'all',

--- a/client/src/components/Admin/SiteConfig.tsx
+++ b/client/src/components/Admin/SiteConfig.tsx
@@ -1,4 +1,4 @@
-import { Container, Separator } from "@radix-ui/themes";
+import { Container, Flex, Separator } from "@radix-ui/themes";
 import { useContext, useEffect, useReducer, useState } from "react";
 import { SiteData } from "../../types/global";
 import PageHeader from "../PageHeader";
@@ -11,11 +11,18 @@ import Input from "../Util/Input";
 
 
 
-type ReducerAction = "setShowDay" | "setShowHour" | "setShowLength" | "setOnBreak" | "toggleOnBreak";
+type ReducerAction = "setShowDay" | "setShowHour" | "setShowLength" | "setOnBreak" | "toggleOnBreak" | "setAnnouncement" | "setAnnouncementExpires" | "setAnnouncementMessage" | "clearAnnouncement";
 
+const normalizeAnnouncementExpires = (expires: Date | string | null | undefined): Date | null => {
+	if (!expires) {
+		return null;
+	}
+
+	const date = new Date(expires);
+	return Number.isNaN(date.getTime()) ? null : date;
+};
 
 const reducer = (state: SiteData, action: { type: ReducerAction; payload?: any }) => {
-
 	switch (action.type) {
 		case "setShowDay": {
 			return { ...state, showDay: action.payload };
@@ -32,6 +39,29 @@ const reducer = (state: SiteData, action: { type: ReducerAction; payload?: any }
 		case "toggleOnBreak": {
 			return { ...state, onBreak: !state.onBreak };
 		}
+		case "setAnnouncement": {
+			return { ...state, announcement: action.payload };
+		}
+		case "setAnnouncementExpires": {
+	
+			return { ...state, announcement: { ...state.announcement, expires: normalizeAnnouncementExpires(action.payload) } };
+		}
+		case "setAnnouncementMessage": {
+			return {
+				...state,
+				announcement: {
+					...state.announcement,
+					message: action.payload,
+					expires: normalizeAnnouncementExpires(state.announcement?.expires),
+				},
+			};
+		}
+		case "clearAnnouncement": {
+			if (state.announcement === null) {
+				return { ...state, announcement: { message: "", expires: null } };
+			}
+			return { ...state, announcement: null };
+		}
 		default: {
 			return state;
 		}
@@ -41,7 +71,7 @@ const reducer = (state: SiteData, action: { type: ReducerAction; payload?: any }
 const SiteConfig = () => {
 	const setError = useContext(ErrorContext)
 	const [loading, setLoading] = useState(true);
-	const [state, dispatch] = useReducer(reducer, {} as SiteData);
+	const [state, dispatch] = useReducer(reducer, { announcement: { message: "", expires: null } } as SiteData);
 
 
 
@@ -52,6 +82,8 @@ const SiteConfig = () => {
 				dispatch({ type: "setShowHour", payload: res.data.showHour });
 				dispatch({ type: "setShowLength", payload: res.data.showLength });
 				dispatch({ type: "setOnBreak", payload: res.data.onBreak });
+
+				// We only set announcement when wanting to update it.
 				setLoading(false);
 			})
 			.catch((error) => {
@@ -68,13 +100,16 @@ const SiteConfig = () => {
 			setError("Please enter valid values for all fields");
 			return;
 		}
-
+		
 		const payload = {
 			...state,
 			showDay: Number(state.showDay),
 			showHour: Number(state.showHour),
 			showLength: Number(state.showLength),
 		};
+		if (state.announcement && state.announcement.message.trim() === "") {
+			delete payload.announcement; // means no update to announcement
+		}
 		const res = await axios.patch("/api/siteInfo", payload);
 		if (res.data.success) {
 			setError("Site configuration updated successfully", "success");
@@ -92,6 +127,14 @@ const SiteConfig = () => {
 		if (!Number.isInteger(day) || day < 0 || day > 6) return false;
 		if (!Number.isInteger(hour) || hour < 0 || hour > 23) return false;
 		if (!Number.isInteger(length) || length < 0) return false;
+		if (state.announcement !== null) {
+			if (state.announcement.expires !== null) {
+				const expiresDate = new Date(state.announcement.expires);
+				if (Number.isNaN(expiresDate.getTime())) return false;
+				if (expiresDate < new Date()) return false; // expires date must be in the future
+			}
+		}
+	
 
 		return true;
 	};
@@ -135,12 +178,30 @@ const SiteConfig = () => {
 					<Form.Message className="text-red-500 font-pixel" match="valueMissing">This field is required</Form.Message>
 					<Form.Message className="text-red-500 font-pixel" match="typeMismatch">Please enter a valid number</Form.Message>
 				</Form.Field>
-				<Form.Field className="flex items-center gap-2" name="onBreak">
+				<Form.Field className="flex flex-col gap-1" name="announcementMessage">
 					<Form.Control asChild>
-						<input type="checkbox" checked={state.onBreak} onChange={() => dispatch({ type: "toggleOnBreak" })} className="w-4 h-4" />
+						<Input label="Announcement Message" type="text" value={state.announcement?.message || ""} onChange={(e) => dispatch({ type: "setAnnouncementMessage", payload: e.target.value })} placeholder="Announcement Message" />
 					</Form.Control>
-					<Form.Label className="font-pixel text-lg">On Break</Form.Label>
 				</Form.Field>
+				<Form.Field className="flex flex-col gap-1" name="announcementExpires">
+					<Form.Control asChild>
+						<Input label="Announcement Expires (YYYY-MM-DD)" type="date" value={state.announcement?.expires ? new Date(state.announcement.expires).toISOString().split("T")[0] : ""} onChange={(e) => dispatch({ type: "setAnnouncementExpires", payload: e.target.value ? new Date(e.target.value) : null })} placeholder="Announcement Expires" />
+					</Form.Control>
+				</Form.Field>
+				<Flex gap="4">
+					<Form.Field className="inline-flex items-center gap-2" name="onBreak">
+						<Form.Control asChild>
+							<input type="checkbox" checked={state.onBreak} onChange={() => dispatch({ type: "toggleOnBreak" })} className="w-4 h-4" />
+						</Form.Control>
+						<Form.Label className="font-pixel text-lg">On Break</Form.Label>
+					</Form.Field>
+					<Form.Field className="inline-flex items-center gap-2" name="clearAnnouncement">
+						<Form.Control asChild>
+							<input type="checkbox" checked={state.announcement === null} onChange={() => dispatch({ type: "clearAnnouncement" })} className="w-4 h-4" />
+						</Form.Control>
+						<Form.Label className="font-pixel text-lg">Clear Announcement?</Form.Label>
+					</Form.Field>
+				</Flex>
 				<button type="submit" className="text-white font-pixel  border p-1 rounded-md focus:outline-none focus:shadow-outline  cursor-pointer HoverButtonStyles">Save Configuration</button>
 			</Form.Root>
 

--- a/client/src/components/Home/Home.tsx
+++ b/client/src/components/Home/Home.tsx
@@ -38,7 +38,7 @@ const Home = React.memo(() => {
 		>
 			<Box className="text-center min-h-3 mb-4 ">
 				<Text size="4" className="font-pixel text-center w-full" >
-					{loading ? "..." : announcementMessage()}
+					{loading ? "..." : announcementMessage() || "\u00A0"}
 				</Text>
 			</Box>
 			<Grid columns={{xs: "1", sm: "2"}} gap={{xs: "0", sm: "6"}} align="center" justify="center">

--- a/client/src/components/Home/Home.tsx
+++ b/client/src/components/Home/Home.tsx
@@ -8,7 +8,26 @@ import { Box, Container, Flex, Grid, Link, Text } from "@radix-ui/themes";
 const Home = React.memo(() => {
 
 	const { siteData, loading } = useContext(SiteDataContext);
-	
+
+	const announcementMessage = () => {
+		if (siteData?.announcement ) {
+			if (
+				siteData.announcement.expires === null ||
+				siteData.announcement.expires > new Date()
+			) {
+				const date = siteData.announcement.timestamp;
+				return `Announcement: ${siteData.announcement.message} (${date
+					.toDateString()
+					.split(" ")
+					.slice(1, 3)
+					.join(" ")})`; // should be month day
+			}
+			else {
+				return "";
+			}
+		}
+		return "";
+	}
 
 	return (
 		<Container size={{
@@ -17,9 +36,11 @@ const Home = React.memo(() => {
 		}}
 		className="px-8 sm:px-0 min-h-screen flex flex-col justify-center items-center Home-Container"
 		>
-			<Text size="4" className="font-pixel text-center w-full mb-4 hidden" >
-				Test Announcement
-			</Text>
+			<Box className="text-center min-h-3 mb-4 ">
+				<Text size="4" className="font-pixel text-center w-full" >
+					{loading ? "..." : announcementMessage()}
+				</Text>
+			</Box>
 			<Grid columns={{xs: "1", sm: "2"}} gap={{xs: "0", sm: "6"}} align="center" justify="center">
 				<Box className="flex font-tiny text-6xl white flex-col text-center">
 					<p className="text-lg font-pixel align-top flex whitespace-nowrap justify-center transition-all duration-300">Next Show Date: {loading ? "..." :  showDateString(siteData!)}</p>

--- a/client/src/providers/SiteDataProvider.tsx
+++ b/client/src/providers/SiteDataProvider.tsx
@@ -13,7 +13,19 @@ const SiteDataProvider = ({ children}: { children: React.ReactNode}) => {
 	useEffect(() => {
 		axios.get<SiteData>("/api/siteInfo")
 			.then((response) => {
-				setSiteData(response.data);
+				let announcement = null;
+				if(response.data.announcement !== null) {
+					let expiresDate = response.data.announcement.expires ? new Date(response.data.announcement.expires) : null;
+					let timestampDate = new Date(response.data.announcement.timestamp);
+					announcement = {
+						message: response.data.announcement?.message,
+						expires: expiresDate,
+						timestamp: timestampDate
+					}
+				}
+
+				
+				setSiteData({ ...response.data, announcement });
 				setLoading(false);
 			})
 			.catch((error) => {

--- a/client/src/types/global.ts
+++ b/client/src/types/global.ts
@@ -34,8 +34,14 @@ export interface SiteData {
 	showHour: number;
 	showLength: number;
 	onBreak: boolean;
-	messageOfTheDay?: string;
+	announcement: {
+		message: string;
+		expires: Date | null;
+		timestamp: Date;
+	} | null
 }
+
+
 
 
 /**

--- a/server/migrations/1785063577848-addAnnouncement.ts
+++ b/server/migrations/1785063577848-addAnnouncement.ts
@@ -1,0 +1,20 @@
+// Import your schemas here
+import type { Connection } from 'mongoose';
+
+export async function up (connection: Connection): Promise<void> {
+	await connection.collection('sitedatas').updateOne({}, {
+		$set: {
+			announcement: null
+		}
+	});
+}
+
+export async function down (connection: Connection): Promise<void> {
+	// Write migration here
+	await connection.collection('sitedatas').updateOne({}, {
+		$unset: {
+			announcement: ""
+		}
+	});
+
+}

--- a/server/src/controllers/SiteData.ts
+++ b/server/src/controllers/SiteData.ts
@@ -1,0 +1,33 @@
+import SiteData from "../models/SiteData.js";
+import { Announcement, SiteDataRequest } from "../types/SiteData.js";
+
+
+
+
+
+export const updateSiteData = async (siteData: SiteDataRequest): Promise<SiteData> => {
+
+	const existingData = await SiteData.findOne({});
+	if (!existingData) {
+		throw new Error("Site data not found");
+	}
+	
+	existingData.set(siteData);
+	
+	if(siteData.announcement){
+		if(siteData.announcement === null) {
+			existingData.announcement = null;
+		}
+		else if(siteData.announcement.message.trim() === "") {
+			existingData.announcement = null;
+		}
+		else {
+			existingData.announcement = {
+				message: siteData.announcement.message,
+				expires: siteData.announcement.expires,
+			} as Announcement; // timestamp set on pre-hook
+		}
+	}
+	await existingData.save({ validateBeforeSave: true }); 
+	return existingData;
+};

--- a/server/src/models/SiteData.ts
+++ b/server/src/models/SiteData.ts
@@ -10,17 +10,16 @@ type SiteModelType = Model<SiteData, {}, {}, SiteDataVirtuals>;
  */
 const siteDataSchema = new Schema<SiteData, SiteModelType>(
 	{
-		_id: { type: String, default: "siteData" },
 		onBreak: { type: Boolean, required: true, default: false },
 		showDay: { type: Number, required: true, default: 0 },
 		showHour: { type: Number, required: true, default: 0 },
 		timezone: { type: String, required: true, default: "America/New_York" },
 		showLength: { type: Number, required: true, default: 1 },
-		messageOfTheDay: { type: String, required: false },
 		announcement: {
 			type: new Schema<Announcement>(
 				{
 					message: { type: String, required: true },
+					expires: { type: Date, required: false, default: null },
 					timestamp: { type: Date, required: true },
 				},
 				{ _id: false }
@@ -34,7 +33,10 @@ const siteDataSchema = new Schema<SiteData, SiteModelType>(
 
 
 siteDataSchema.pre("validate", function () {
-	if (this.isModified("announcement.message") && this.announcement) {
+	if (this.announcement && this.isModified("announcement")) {
+		if (this.announcement.expires && this.announcement.expires < new Date()) {
+			this.announcement.expires = null;
+		}
 		this.announcement.timestamp = new Date();
 	}
 });

--- a/server/src/models/SiteData.ts
+++ b/server/src/models/SiteData.ts
@@ -1,5 +1,5 @@
 import { Schema, model, Model } from "mongoose";
-import { SiteData, SiteDataVirtuals } from "../types/SiteData.js";
+import { Announcement, SiteData, SiteDataVirtuals } from "../types/SiteData.js";
 
 
 
@@ -10,15 +10,34 @@ type SiteModelType = Model<SiteData, {}, {}, SiteDataVirtuals>;
  */
 const siteDataSchema = new Schema<SiteData, SiteModelType>(
 	{
+		_id: { type: String, default: "siteData" },
 		onBreak: { type: Boolean, required: true, default: false },
 		showDay: { type: Number, required: true, default: 0 },
 		showHour: { type: Number, required: true, default: 0 },
 		timezone: { type: String, required: true, default: "America/New_York" },
 		showLength: { type: Number, required: true, default: 1 },
 		messageOfTheDay: { type: String, required: false },
+		announcement: {
+			type: new Schema<Announcement>(
+				{
+					message: { type: String, required: true },
+					timestamp: { type: Date, required: true },
+				},
+				{ _id: false }
+			),
+			required: false,
+			default: undefined,
+		}
 	},
 );
 
+
+
+siteDataSchema.pre("validate", function () {
+	if (this.isModified("announcement.message") && this.announcement) {
+		this.announcement.timestamp = new Date();
+	}
+});
 
 siteDataSchema.virtual("lastShowDate").get(function (this: SiteData): Date {
 	const now = new Date();

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -30,13 +30,19 @@ router.get("/siteInfo", async (req, res) => {
 router.patch("/siteInfo", requireLogin, async(req: Request, res: Response) => {
 
 	//TODO: Validate req.body fields with zod
-	SiteData.findOneAndUpdate({}, req.body, { new: true })
-		.then((updatedData) => {
-			res.json({ success: true, data: updatedData });
-		})
-		.catch((error) => {
-			res.status(500).json({ success: false, message: "Error updating site info", error });
-		});
+	try {
+		const siteData = await SiteData.findOne({});
+		if (!siteData) {
+			res.status(404).json({ success: false, message: "Site info not found" });
+			return;
+		}
+
+		siteData.set(req.body);
+		await siteData.save();
+		res.json({ success: true, data: siteData });
+	} catch (error) {
+		res.status(500).json({ success: false, message: "Error updating site info", error });
+	}
 });
 
 router.get("/getStats", async (req, res) => {

--- a/server/src/tests/migrations.test.ts
+++ b/server/src/tests/migrations.test.ts
@@ -2,9 +2,14 @@ import { $ } from "bun";
 import { describe, beforeAll,afterAll, expect, test } from "bun:test";
 import { clearDatabase, connectToDatabase, db } from "../config/db.js";
 import initializeApp from "../init.js";
-import { Connection } from "mongoose";
+import { Connection, Types } from "mongoose";
 import { migrator } from "../migrations.js";
 import { Migrator } from "ts-migrate-mongoose";
+
+type SiteDataDocument = {
+	_id: Types.ObjectId;
+	[key: string]: unknown;
+};
 
 describe.if(process.env.TEST_MIGRATIONS === "true")("Migrations", () => {
 	let connection : Connection;
@@ -51,6 +56,14 @@ describe.if(process.env.TEST_MIGRATIONS === "true")("Migrations", () => {
 		expect(connection.collection("songentries").countDocuments({ duration: { $gt: 60 } })).resolves.toBeGreaterThan(0);
 	});
 
+	test("Add announcement", async() => {
+		const siteDataCollection = connection.collection<SiteDataDocument>("sitedatas");
+		await localMigrator.run("up", "addAnnouncement");
+
+		const siteData = await siteDataCollection.findOne({});
+		expect(siteData).not.toBeNull();
+		expect(siteData?.announcement).toBeNull();
+	});
 
 
 });

--- a/server/src/tests/sitedata.test.ts
+++ b/server/src/tests/sitedata.test.ts
@@ -63,7 +63,6 @@ describe("Update Site Data", function() {
 			showHour: 5,
 			timezone: "America/Los_Angeles",
 			showLength: 2,
-			messageOfTheDay: "We are on break!"
 		};
 		const res: request.Response & {body: {success: boolean; data: SiteData}} = await agent
 			.patch("/api/siteInfo")
@@ -77,7 +76,6 @@ describe("Update Site Data", function() {
 		expect(body.data.showHour).toBe(5);
 		expect(body.data.timezone).toBe("America/Los_Angeles");
 		expect(body.data.showLength).toBe(2);
-		expect(body.data.messageOfTheDay).toBe("We are on break!");
 	});
 
 	test("should timestamp an announcement update", async () => {
@@ -90,9 +88,63 @@ describe("Update Site Data", function() {
 		expect(res.status).toBe(200);
 		expect(res.body.success).toBe(true);
 		expect(res.body.data.announcement.message).toBe("The next show starts soon.");
+		expect(res.body.data.announcement.expires).toBeNull();
 
 		const timestamp = new Date(res.body.data.announcement.timestamp).getTime();
 		expect(timestamp).toBeGreaterThanOrEqual(beforeRequest);
 		expect(timestamp).toBeLessThanOrEqual(afterRequest);
+	});
+
+	test("should save an announcement expiration date", async () => {
+		const expires = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+		const res = await agent
+			.patch("/api/siteInfo")
+			.send({ announcement: { message: "Tonight's show is delayed.", expires } });
+
+		expect(res.status).toBe(200);
+		expect(res.body.success).toBe(true);
+		expect(res.body.data.announcement.message).toBe("Tonight's show is delayed.");
+		expect(new Date(res.body.data.announcement.expires).toISOString()).toBe(expires);
+	});
+
+	test("should replace an existing announcement", async () => {
+		await agent
+			.patch("/api/siteInfo")
+			.send({ announcement: { message: "The next show starts soon." } });
+
+		const expires = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+		const res = await agent
+			.patch("/api/siteInfo")
+			.send({ announcement: { message: "Tonight's show is delayed.", expires } });
+
+		expect(res.status).toBe(200);
+		expect(res.body.success).toBe(true);
+		expect(res.body.data.announcement.message).toBe("Tonight's show is delayed.");
+		expect(new Date(res.body.data.announcement.expires).toISOString()).toBe(expires);
+		expect(res.body.data.announcement.timestamp).toBeDefined();
+	});
+
+	test("should retain an announcement when updating other site data", async () => {
+		const announcement = { message: "The next show starts soon." };
+		await agent.patch("/api/siteInfo").send({ announcement });
+
+		const res = await agent.patch("/api/siteInfo").send({ showHour: 7 });
+
+		expect(res.status).toBe(200);
+		expect(res.body.success).toBe(true);
+		expect(res.body.data.showHour).toBe(7);
+		expect(res.body.data.announcement.message).toBe(announcement.message);
+	});
+
+	test("should clear an existing announcement", async () => {
+		await agent
+			.patch("/api/siteInfo")
+			.send({ announcement: { message: "The next show starts soon." } });
+
+		const res = await agent.patch("/api/siteInfo").send({ announcement: null });
+
+		expect(res.status).toBe(200);
+		expect(res.body.success).toBe(true);
+		expect(res.body.data.announcement).toBeNull();
 	});
 });

--- a/server/src/tests/sitedata.test.ts
+++ b/server/src/tests/sitedata.test.ts
@@ -79,4 +79,20 @@ describe("Update Site Data", function() {
 		expect(body.data.showLength).toBe(2);
 		expect(body.data.messageOfTheDay).toBe("We are on break!");
 	});
+
+	test("should timestamp an announcement update", async () => {
+		const beforeRequest = Date.now();
+		const res = await agent
+			.patch("/api/siteInfo")
+			.send({ announcement: { message: "The next show starts soon." } });
+		const afterRequest = Date.now();
+
+		expect(res.status).toBe(200);
+		expect(res.body.success).toBe(true);
+		expect(res.body.data.announcement.message).toBe("The next show starts soon.");
+
+		const timestamp = new Date(res.body.data.announcement.timestamp).getTime();
+		expect(timestamp).toBeGreaterThanOrEqual(beforeRequest);
+		expect(timestamp).toBeLessThanOrEqual(afterRequest);
+	});
 });

--- a/server/src/types/SiteData.ts
+++ b/server/src/types/SiteData.ts
@@ -1,16 +1,30 @@
+import { Types } from "mongoose";
+
 interface SiteData {
-    _id?: string;
+    _id: Types.ObjectId;
     onBreak: boolean;
     showDay: number;
     showHour: number;
     timezone: string;
     showLength: number;
-    messageOfTheDay?: string;
     announcement: Announcement | null;
 }
 
-export type Announcement = {
+interface SiteDataRequest {
+    onBreak: boolean;
+    showDay: number;
+    showHour: number;
+    timezone: string;
+    showLength: number;
+    announcement?: {
+        message: string;
+        expires: Date | null;
+    }
+}
+
+type Announcement = {
     message: string;
+    expires: Date | null;
     timestamp: Date;
 }
 
@@ -19,4 +33,4 @@ interface SiteDataVirtuals extends SiteData {
     nextShowDate: Date;
 }
 
-export { SiteData, SiteDataVirtuals };
+export { SiteData, SiteDataRequest, Announcement, SiteDataVirtuals };

--- a/server/src/types/SiteData.ts
+++ b/server/src/types/SiteData.ts
@@ -1,10 +1,17 @@
 interface SiteData {
+    _id?: string;
     onBreak: boolean;
     showDay: number;
     showHour: number;
     timezone: string;
     showLength: number;
     messageOfTheDay?: string;
+    announcement: Announcement | null;
+}
+
+export type Announcement = {
+    message: string;
+    timestamp: Date;
 }
 
 interface SiteDataVirtuals extends SiteData {


### PR DESCRIPTION
## Summary

Preserves the homepage announcement line when no announcement is available, preventing the vertically centered content from shifting after loading.

## Validation

- pnpm --dir client exec eslint src/components/Home/Home.tsx

## Root cause

An empty announcement rendered no inline content, so the announcement row became shorter than the loading placeholder.